### PR TITLE
Modernisation for Laravel 12+ and PHP 8.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,14 @@
-# laravel-soap-server
+# Laravel SOAP Server
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/kduma/laravel-soap-server.svg?style=flat-square)](https://packagist.org/packages/kduma/laravel-soap-server)
-[![Build Status](https://img.shields.io/travis/kduma/laravel-soap-server/master.svg?style=flat-square)](https://travis-ci.org/kduma/laravel-soap-server)
-[![Quality Score](https://img.shields.io/scrutinizer/g/kduma/laravel-soap-server.svg?style=flat-square)](https://scrutinizer-ci.com/g/kduma/laravel-soap-server)
-[![Total Downloads](https://img.shields.io/packagist/dt/kduma/laravel-soap-server.svg?style=flat-square)](https://packagist.org/packages/kduma/laravel-soap-server)
-
-Laravel SOAP service server
+Wrapper for creating SOAP web service servers in Laravel using Laminas/Soap.
 
 ## Requirements
 
 - PHP `^8.3`
 - Laravel `^12.0 || ^13.0`
-- laminas/laminas-soap `^2.11 || ^3.0`
+- `ext-soap`
 
 ## Installation
-
-You can install the package via composer:
 
 ```bash
 composer require kduma/laravel-soap-server
@@ -23,134 +16,34 @@ composer require kduma/laravel-soap-server
 
 ## Usage
 
-Create server class - remember to provide correct typehints and doc blocks:
+Create a service class:
+
 ```php
-class SoapDemoServer
+class MathService
 {
-    /**
-     * Adds two numbers
-     *
-     * @param float $a
-     * @param float $b
-     *
-     * @return float
-     */
-    public function sum(float $a = 0, float $b = 0): float
+    /** @param float $a */
+    /** @param float $b */
+    public function add(float $a = 0, float $b = 0): float
     {
         return $a + $b;
     }
-
-    /**
-     * Returns your data
-     *
-     * @return Person
-     */
-    public function me(): Person
-    {
-        return new Person('John', 'Doe');
-    }
-
-    /**
-     * Says hello to person provided
-     *
-     * @param Person $person
-     *
-     * @return string
-     */
-    public function hello(Person $person): string
-    {
-        return sprintf("Hello %s!", $person->first_name);
-    }
 }
 ```
 
-...and DTO objects:
-```php
-class Person
-{
-    /**
-     * @var string
-     */
-    public $first_name;
+Create a controller:
 
-    /**
-     * @var string
-     */
-    public $last_name;
-
-    /**
-     * @param string $first_name
-     * @param string $last_name
-     */
-    public function __construct(string $first_name, string $last_name)
-    {
-        $this->first_name = $first_name;
-        $this->last_name = $last_name;
-    }
-}
-```
-
-Create controller class for your SOAP server:
 ```php
 class MySoapController extends \KDuma\SoapServer\AbstractSoapServerController
 {
-    protected function getService(): string
-    {
-        return SoapDemoServer::class;
-    }
-
-    protected function getEndpoint(): string
-    {
-        return route('my_soap_server');
-    }
-
-    protected function getWsdlUri(): string
-    {
-        return route('my_soap_server.wsdl');
-    }
-
-    protected function getClassmap(): array
-    {
-        return [
-            'SoapPerson' => Person::class,
-        ];
-    }
+    protected function getService(): string { return MathService::class; }
+    protected function getEndpoint(): string { return route('soap'); }
+    protected function getWsdlUri(): string { return route('soap.wsdl'); }
 }
 ```
 
-Register routes in your routes file:
+Register routes:
+
 ```php
-Route::name('my_soap_server.wsdl')->get('/soap.wsdl', [MySoapController::class, 'wsdlProvider']);
-Route::name('my_soap_server')->post('/soap', [MySoapController::class, 'soapServer']);
+Route::name('soap.wsdl')->get('/soap.wsdl', [MySoapController::class, 'wsdlProvider']);
+Route::name('soap')->post('/soap', [MySoapController::class, 'soapServer']);
 ```
-
-### Testing
-
-``` bash
-composer test
-```
-
-### Changelog
-
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
-
-## Contributing
-
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
-
-### Security
-
-If you discover any security related issues, please email git@krystian.duma.sh instead of using the issue tracker.
-
-## Credits
-
-- [Krystian Duma](https://github.com/kduma)
-- [All Contributors](../../contributors)
-
-## License
-
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-
-## Laravel Package Boilerplate
-
-This package was generated using the [Laravel Package Boilerplate](https://laravelpackageboilerplate.com).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 Laravel SOAP service server
 
+## Requirements
+
+- PHP `^8.3`
+- Laravel `^12.0 || ^13.0`
+- laminas/laminas-soap `^2.11 || ^3.0`
+
 ## Installation
 
 You can install the package via composer:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Laravel SOAP Server
 
+[![Latest Stable Version](https://poser.pugx.org/kduma/laravel-soap-server/v/stable.svg)](https://packagist.org/packages/kduma/laravel-soap-server)
+[![Total Downloads](https://poser.pugx.org/kduma/laravel-soap-server/downloads.svg)](https://packagist.org/packages/kduma/laravel-soap-server)
+[![License](https://poser.pugx.org/kduma/laravel-soap-server/license.svg)](https://packagist.org/packages/kduma/laravel-soap-server)
+
 Wrapper for creating SOAP web service servers in Laravel using Laminas/Soap.
 
 ## Requirements

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,14 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0|^8.1|^8.2",
-        "laminas/laminas-soap": "^2.11",
-        "ext-soap": "*"
+        "php": "^8.3",
+        "ext-soap": "*",
+        "laminas/laminas-soap": "^2.11 || ^3.0",
+        "illuminate/routing": "^12.0 || ^13.0",
+        "illuminate/support": "^12.0 || ^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "^9.0 || ^10.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^9.0 || ^10.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/AbstractSoapServerController.php
+++ b/src/AbstractSoapServerController.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\SoapServer;
 

--- a/src/AbstractSoapServerController.php
+++ b/src/AbstractSoapServerController.php
@@ -192,7 +192,7 @@ abstract class AbstractSoapServerController extends BaseController
         report($exception);
 
         $faultcode = 'SOAP-ENV:Server';
-        $faultstring = $exception->getMessage();
+        $faultstring = htmlspecialchars($exception->getMessage(), ENT_XML1, 'UTF-8');
 
         return <<<XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/AbstractSoapServerController.php
+++ b/src/AbstractSoapServerController.php
@@ -8,6 +8,7 @@ use SoapFault;
 use Laminas\Soap\Wsdl;
 use Laminas\Soap\Server;
 use Laminas\Soap\AutoDiscover;
+use Illuminate\Http\Response;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Contracts\Container\Container;
 use Laminas\Soap\Server\DocumentLiteralWrapper;
@@ -112,7 +113,7 @@ abstract class AbstractSoapServerController extends BaseController
         return config('soap-server.wsdl_formatting_enabled');
     }
 
-    public function wsdlProvider(ResponseFactory $responseFactory)
+    public function wsdlProvider(ResponseFactory $responseFactory): Response
     {
         $this->disableSoapCacheWhenNeeded();
 
@@ -151,7 +152,7 @@ abstract class AbstractSoapServerController extends BaseController
         return $responseFactory->make($dom->saveXML(), 200, $this->getWsdlHeaders());
     }
 
-    public function soapServer(Container $container, ResponseFactory $responseFactory)
+    public function soapServer(Container $container, ResponseFactory $responseFactory): Response
     {
         $this->disableSoapCacheWhenNeeded();
 
@@ -186,7 +187,7 @@ abstract class AbstractSoapServerController extends BaseController
      *
      * @return string
      */
-    protected static function serverFault(\Exception $exception)
+    protected static function serverFault(\Exception $exception): string
     {
         report($exception);
 

--- a/src/BetterReflectionDiscovery.php
+++ b/src/BetterReflectionDiscovery.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\SoapServer;
 

--- a/src/BetterReflectionDiscovery.php
+++ b/src/BetterReflectionDiscovery.php
@@ -18,7 +18,7 @@ class BetterReflectionDiscovery implements DiscoveryStrategyInterface
      * @param  AbstractFunction $function
      * @return string
      */
-    public function getFunctionDocumentation(AbstractFunction $function)
+    public function getFunctionDocumentation(AbstractFunction $function): string
     {
         return $function->getDescription();
     }
@@ -29,7 +29,7 @@ class BetterReflectionDiscovery implements DiscoveryStrategyInterface
      * @param  ReflectionParameter $param
      * @return string
      */
-    public function getFunctionParameterType(ReflectionParameter $param)
+    public function getFunctionParameterType(ReflectionParameter $param): string
     {
         /** @var \ReflectionParameter $reflection */
         $reflection = $this->getProtectedValue($param, ReflectionParameter::class);
@@ -51,7 +51,7 @@ class BetterReflectionDiscovery implements DiscoveryStrategyInterface
      * @param  Prototype        $prototype
      * @return string
      */
-    public function getFunctionReturnType(AbstractFunction $function, Prototype $prototype)
+    public function getFunctionReturnType(AbstractFunction $function, Prototype $prototype): string
     {
         /** @var \ReflectionFunctionAbstract $reflection */
         $reflection = $this->getProtectedValue($function, AbstractFunction::class);
@@ -73,9 +73,9 @@ class BetterReflectionDiscovery implements DiscoveryStrategyInterface
      * @param  Prototype        $prototype
      * @return bool
      */
-    public function isFunctionOneWay(AbstractFunction $function, Prototype $prototype)
+    public function isFunctionOneWay(AbstractFunction $function, Prototype $prototype): bool
     {
-        return $this->getFunctionReturnType($function, $prototype) == 'void';
+        return $this->getFunctionReturnType($function, $prototype) === 'void';
     }
 
     /**
@@ -85,7 +85,7 @@ class BetterReflectionDiscovery implements DiscoveryStrategyInterface
      *
      * @return object
      */
-    protected function getProtectedValue($param, string $class)
+    protected function getProtectedValue(object $param, string $class): object
     {
         $reflectionProperty = new \ReflectionProperty($class, 'reflection');
         $reflectionProperty->setAccessible(true);

--- a/src/LaravelSoapServerServiceProvider.php
+++ b/src/LaravelSoapServerServiceProvider.php
@@ -11,7 +11,7 @@ class LaravelSoapServerServiceProvider extends ServiceProvider
     /**
      * Bootstrap the application services.
      */
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -23,7 +23,7 @@ class LaravelSoapServerServiceProvider extends ServiceProvider
     /**
      * Register the application services.
      */
-    public function register()
+    public function register(): void
     {
         // Automatically apply the package configuration
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'soap-server');

--- a/src/LaravelSoapServerServiceProvider.php
+++ b/src/LaravelSoapServerServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\SoapServer;
 
 use Illuminate\Support\ServiceProvider;


### PR DESCRIPTION
## Summary
- Bump PHP requirement to `^8.3`
- Add `illuminate/routing` and `illuminate/support` `^12.0 || ^13.0`
- Bump `laminas/laminas-soap` to `^2.11 || ^3.0`
- Add `declare(strict_types=1)` to all source files
- Add full return types and parameter types to all methods